### PR TITLE
Handle nested Dockerfile paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -153,7 +154,7 @@ func main() {
 		}
 
 		args = append(args, "--file")
-		args = append(args, fmt.Sprintf("%v/%v", *path, *dockerfile))
+		args = append(args, filepath.Join(*path, filepath.Base(*dockerfile)))
 		args = append(args, *path)
 		runCommand("docker", args)
 


### PR DESCRIPTION
There was an issue with the previous implementation if we wanted to use a `Dockerfile` which wasn't in the root.

If we specified

```
dockerfile: ./foo/Dockerfile
path: ./bar
```

Then copying `./foo/Dockerfile` into `./bar` was correct, but then to `docker build` the Dockerfile was passed in incorrectly like this:

```
docker build ... --file ./bar/./foo/Dockerfile ...
```

This PR fixing this by extracting just the filename part (with `filepath.Base()` from the path of the Dockerfile.

(The actual scenario I need this for is the build of a library, which is not a deployable API, so it doesn't have a `Dockerfile` of its own, but it has a documentation site I'd like to build, which does have a `Dockerfile`. But since it's the `Dockerfile` of not the whole project, but just the docs site, I'd like to keep it under the `./docs` folder.)