### PR TITLE
Only copy the Dockerfile if it's not in the right place already

### DIFF
--- a/main.go
+++ b/main.go
@@ -119,8 +119,8 @@ func main() {
 		log.Printf("Ensuring build directory %v exists\n", *path)
 		runCommand("mkdir", []string{"-p", *path})
 
-		// add dockerfile to items to copy if path is non-default and dockerfile isn't in the list to copy already
-		if *path != "." && !contains(copySlice, *dockerfile) {
+		// add dockerfile to items to copy if path is non-default, and dockerfile isn't in the list to copy already, and if it is not there already
+		if *path != "." && !contains(copySlice, *dockerfile) && filepath.Clean(filepath.Dir(*dockerfile)) != filepath.Clean(*path) {
 			copySlice = append(copySlice, *dockerfile)
 		}
 


### PR DESCRIPTION
In the previous (#1) PR I forgot about one case: when we are using a custom `path`, but the `Dockerfile` is already in the right place. In this case we shouldn't try to copy it, because the build will fail with this:

```
...
Running command 'cp -r foo/Dockerfile ./foo'...
cp: 'foo/Dockerfile' and 'foo/Dockerfile' are the same file
exit status 1
```

So with this change we're checking if `Dockerfile` is already in the directory specified by `path`, and we only add it to the list of files to copy, if it's not there yet.