### PR TITLE
update trivy to 0.10.1

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -34,7 +34,7 @@ stages:
           tar -xzf - -C / \
           && /dive version
 
-      ARG TRIVY_VERSION=0.9.1
+      ARG TRIVY_VERSION=0.10.1
 
       RUN wget -O- https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz | \
           tar -xzf - -C / \


### PR DESCRIPTION
Includes the following releases:

- https://github.com/aquasecurity/trivy/releases/tag/v0.10.0
- https://github.com/aquasecurity/trivy/releases/tag/v0.10.1