### PR TITLE
Docker layer caching

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -13,7 +13,7 @@ version:
 
 stages:
   build:
-    image: golang:1.16.0-alpine
+    image: golang:1.16-alpine
     env:
       CGO_ENABLED: 0
       GOOS: linux

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -137,7 +137,7 @@ stages:
           ENTRYPOINT ["/${ESTAFETTE_GIT_NAME}"]
         repositories:
         - extensions
-        path: ./publish
+        path: ./publish-2
         copy:
         - /etc/ssl/certs/ca-certificates.crt
 

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -140,6 +140,7 @@ stages:
         path: ./publish-2
         copy:
         - /etc/ssl/certs/ca-certificates.crt
+        - ./
 
       test-build-from-private-registry:
         image: extensions/docker:${ESTAFETTE_BUILD_VERSION}

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -34,7 +34,7 @@ stages:
           tar -xzf - -C / \
           && /dive version
 
-      ARG TRIVY_VERSION=0.16.0
+      ARG TRIVY_VERSION=0.18.2
 
       RUN wget -O- https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz | \
           tar -xzf - -C / \

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -34,7 +34,7 @@ stages:
           tar -xzf - -C / \
           && /dive version
 
-      ARG TRIVY_VERSION=0.18.2
+      ARG TRIVY_VERSION=0.17.2
 
       RUN wget -O- https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz | \
           tar -xzf - -C / \

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -34,7 +34,7 @@ stages:
           tar -xzf - -C / \
           && /dive version
 
-      ARG TRIVY_VERSION=0.17.2
+      ARG TRIVY_VERSION=0.16.0
 
       RUN wget -O- https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz | \
           tar -xzf - -C / \

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -125,7 +125,7 @@ stages:
 
           COPY . .
 
-          RUN docker build
+          RUN go build
 
           FROM docker:19.03.13 AS runtime
 

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -182,6 +182,7 @@ stages:
       test-trivy:
         image: extensions/docker:${ESTAFETTE_BUILD_VERSION}
         action: trivy
+        severity: critical
         container: docker
         repositories:
         - extensions

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -115,7 +115,7 @@ stages:
         action: build
         container: docker-test
         inline: |
-          FROM docker:19.03.13 AS builder
+          FROM golang:1.16-alpine AS builder
 
           RUN apk update \
               && apk add --no-cache --upgrade \
@@ -127,7 +127,7 @@ stages:
 
           RUN go build
 
-          FROM docker:19.03.13 AS runtime
+          FROM golang:1.16-alpine AS runtime
 
           LABEL maintainer="estafette.io"
 

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -110,6 +110,37 @@ stages:
         copy:
         - /etc/ssl/certs/ca-certificates.crt
 
+      test-multistage-build:
+        image: extensions/docker:${ESTAFETTE_BUILD_VERSION}
+        action: build
+        container: docker-test
+        inline: |
+          FROM docker:19.03.13 AS builder
+
+          RUN apk update \
+              && apk add --no-cache --upgrade \
+                  git \
+              && rm -rf /var/cache/apk/* \
+              && git version
+
+          COPY . .
+
+          RUN docker build
+
+          FROM docker:19.03.13 AS runtime
+
+          LABEL maintainer="estafette.io"
+
+          COPY --from=0 /estafette-work/${ESTAFETTE_GIT_NAME} /
+          COPY ca-certificates.crt /etc/ssl/certs/
+
+          ENTRYPOINT ["/${ESTAFETTE_GIT_NAME}"]
+        repositories:
+        - extensions
+        path: ./publish
+        copy:
+        - /etc/ssl/certs/ca-certificates.crt
+
       test-build-from-private-registry:
         image: extensions/docker:${ESTAFETTE_BUILD_VERSION}
         action: build

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -123,15 +123,10 @@ stages:
               && rm -rf /var/cache/apk/* \
               && git version
 
-          COPY . .
-
-          RUN go build
-
           FROM golang:1.16-alpine AS runtime
 
           LABEL maintainer="estafette.io"
 
-          COPY --from=0 /estafette-work/${ESTAFETTE_GIT_NAME} /
           COPY ca-certificates.crt /etc/ssl/certs/
 
           ENTRYPOINT ["/${ESTAFETTE_GIT_NAME}"]
@@ -140,7 +135,6 @@ stages:
         path: ./publish-2
         copy:
         - /etc/ssl/certs/ca-certificates.crt
-        - ./
 
       test-build-from-private-registry:
         image: extensions/docker:${ESTAFETTE_BUILD_VERSION}

--- a/main.go
+++ b/main.go
@@ -654,6 +654,8 @@ func main() {
 			log.Fatal().Msgf("Trivy is currently not supported for windows!")
 		}
 
+		foundation.RunCommand(ctx, "/trivy --version")
+
 		if *tag != "" {
 			estafetteBuildVersionAsTag = *tag
 		}

--- a/main.go
+++ b/main.go
@@ -288,11 +288,13 @@ func main() {
 		fmt.Println(targetDockerfile)
 		log.Info().Msg("")
 
-		if *target == "" && !*noCache && runtime.GOOS != "windows" {
+		if *target == "" && !*noCache && runtime.GOOS != "windows" && len(fromImagePaths) > 0 {
 
 			// build every layer separately and push it to registry to be used as cache next time
 			multiCacheFromArgs := []string{}
 			for i := range fromImagePaths {
+
+				log.Info().Msgf("Building layer %v...", i)
 
 				gitBranchAsTag := tidyTag(fmt.Sprintf("dlc-%v-%v", *gitBranch, i))
 				cacheContainerPath := fmt.Sprintf("%v/%v:%v", repositoriesSlice[0], *container, gitBranchAsTag)
@@ -774,6 +776,8 @@ func getFromImagePathsFromDockerfile(dockerfileContent string) ([]string, error)
 			}
 		}
 	}
+
+	log.Info().Msgf("Found %v stages in Dockerfile", len(containerImages))
 
 	return containerImages, nil
 }

--- a/main.go
+++ b/main.go
@@ -303,7 +303,7 @@ func main() {
 
 				log.Info().Msgf("Building layer %v...", i.imagePath)
 
-				gitBranchAsTag := tidyTag(fmt.Sprintf("dlc-%v-%v", *gitBranch, i.imagePath))
+				gitBranchAsTag := tidyTag(fmt.Sprintf("dlc-%v-%v", *gitBranch, i.stageName))
 				cacheContainerPath := fmt.Sprintf("%v/%v:%v", repositoriesSlice[0], *container, gitBranchAsTag)
 				multiCacheFromArgs = append(multiCacheFromArgs, cacheContainerPath)
 
@@ -324,7 +324,7 @@ func main() {
 					}
 				}
 
-				args = append(args, "--target", i.imagePath)
+				args = append(args, "--target", i.stageName)
 
 				// add optional build args
 				for _, a := range argsSlice {

--- a/main_test.go
+++ b/main_test.go
@@ -227,15 +227,30 @@ func TestGetCredentialsForContainers(t *testing.T) {
 }
 
 func TestGetFromImagePathsFromDockerfile(t *testing.T) {
-	t.Run("ReturnsNoContainerImagesIfOnlyFromUsesOfficialDockerHubImage", func(t *testing.T) {
+	t.Run("ReturnContainerImagesIfFromUsesOfficialDockerHubImage", func(t *testing.T) {
 
-		dockerfileContent := "FROM nginx"
+		dockerfileContent := `FROM docker:19.03.13
+
+RUN apk update \
+    && apk add --no-cache --upgrade \
+        git \
+    && rm -rf /var/cache/apk/* \
+    && git version
+
+LABEL maintainer="estafette.io"
+
+COPY estafette-extension-docker /
+COPY ca-certificates.crt /etc/ssl/certs/
+
+ENTRYPOINT ["/estafette-extension-docker"]`
 
 		// act
 		containerImages, err := getFromImagePathsFromDockerfile(dockerfileContent)
 
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(containerImages))
+		assert.Equal(t, 1, len(containerImages))
+		assert.Equal(t, "docker:19.03.13", containerImages[0].imagePath)
+		assert.Equal(t, true, containerImages[0].isOfficialDockerHubImage)
 	})
 
 	t.Run("ReturnsContainerImageForFromWithoutTag", func(t *testing.T) {
@@ -247,7 +262,8 @@ func TestGetFromImagePathsFromDockerfile(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(containerImages))
-		assert.Equal(t, "prom/prometheus", containerImages[0])
+		assert.Equal(t, "prom/prometheus", containerImages[0].imagePath)
+		assert.Equal(t, false, containerImages[0].isOfficialDockerHubImage)
 	})
 
 	t.Run("ReturnsContainerImageForFromWithTag", func(t *testing.T) {
@@ -259,7 +275,8 @@ func TestGetFromImagePathsFromDockerfile(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(containerImages))
-		assert.Equal(t, "prom/prometheus:latest", containerImages[0])
+		assert.Equal(t, "prom/prometheus:latest", containerImages[0].imagePath)
+		assert.Equal(t, false, containerImages[0].isOfficialDockerHubImage)
 	})
 
 	t.Run("ReturnsContainerImageForFromWithTagAndAsAlias", func(t *testing.T) {
@@ -271,7 +288,8 @@ func TestGetFromImagePathsFromDockerfile(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(containerImages))
-		assert.Equal(t, "prom/prometheus:latest", containerImages[0])
+		assert.Equal(t, "prom/prometheus:latest", containerImages[0].imagePath)
+		assert.Equal(t, false, containerImages[0].isOfficialDockerHubImage)
 	})
 
 	t.Run("ReturnsContainerImageForFromWithTagAndAsAlias", func(t *testing.T) {
@@ -283,7 +301,8 @@ func TestGetFromImagePathsFromDockerfile(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(containerImages))
-		assert.Equal(t, "prom/prometheus:latest", containerImages[0])
+		assert.Equal(t, "prom/prometheus:latest", containerImages[0].imagePath)
+		assert.Equal(t, false, containerImages[0].isOfficialDockerHubImage)
 	})
 
 	t.Run("ReturnsContainerImagesFromMultiStageFile", func(t *testing.T) {
@@ -295,8 +314,10 @@ func TestGetFromImagePathsFromDockerfile(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, 2, len(containerImages))
-		assert.Equal(t, "prom/prometheus:latest", containerImages[0])
-		assert.Equal(t, "grafana/grafana:6.1.4", containerImages[1])
+		assert.Equal(t, "prom/prometheus:latest", containerImages[0].imagePath)
+		assert.Equal(t, false, containerImages[0].isOfficialDockerHubImage)
+		assert.Equal(t, "grafana/grafana:6.1.4", containerImages[1].imagePath)
+		assert.Equal(t, false, containerImages[1].isOfficialDockerHubImage)
 	})
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -316,8 +316,10 @@ ENTRYPOINT ["/estafette-extension-docker"]`
 		assert.Equal(t, 2, len(containerImages))
 		assert.Equal(t, "prom/prometheus:latest", containerImages[0].imagePath)
 		assert.Equal(t, false, containerImages[0].isOfficialDockerHubImage)
+		assert.Equal(t, "builder", containerImages[0].stageName)
 		assert.Equal(t, "grafana/grafana:6.1.4", containerImages[1].imagePath)
 		assert.Equal(t, false, containerImages[1].isOfficialDockerHubImage)
+		assert.Equal(t, "", containerImages[1].stageName)
 	})
 }
 


### PR DESCRIPTION
For multistage Dockerfiles with all stages named it does a build per stage - using the `--target` flag - and pushes it to the repository. This can hugely speed up multistage builds by also being able to use cached layers for all stages, instead of only the final stage.