### PR TITLE
Updated Trivy version

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -47,7 +47,7 @@ stages:
         severity: critical
         noCachePush: true
         inline: |
-          FROM docker:dlc
+          FROM docker:latest
 
           RUN apk update \
               && apk add --no-cache --upgrade \

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -47,7 +47,7 @@ stages:
         severity: critical
         noCachePush: true
         inline: |
-          FROM docker:latest
+          FROM docker:dlc
 
           RUN apk update \
               && apk add --no-cache --upgrade \
@@ -100,7 +100,7 @@ stages:
         no-cache: true
         container: hugo-test
         inline: |
-          FROM extensions/docker:latest
+          FROM extensions/docker:dlc
 
           COPY ca-certificates.crt /etc/ssl/certs/
           COPY publish /publish

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,6 +1,3 @@
 # awaiting to fix https://github.com/aquasecurity/trivy/issues/1523
 CVE-2021-41092
 CVE-2021-41103
-# awaiting to fix https://github.com/aquasecurity/trivy/issues/1870
-GMS-2022-20
-CVE-2022-0778

--- a/.trivyignore
+++ b/.trivyignore
@@ -4,3 +4,4 @@ CVE-2021-41103
 # awaiting to fix https://github.com/aquasecurity/trivy/issues/1870
 CVE-2021-43816
 GMS-2022-20
+CVE-2022-0778

--- a/.trivyignore
+++ b/.trivyignore
@@ -2,6 +2,6 @@
 CVE-2021-41092
 CVE-2021-41103
 # awaiting to fix https://github.com/aquasecurity/trivy/issues/1870
-CVE-2021-43816
+# CVE-2021-43816
 GMS-2022-20
 CVE-2022-0778

--- a/.trivyignore
+++ b/.trivyignore
@@ -2,6 +2,5 @@
 CVE-2021-41092
 CVE-2021-41103
 # awaiting to fix https://github.com/aquasecurity/trivy/issues/1870
-# CVE-2021-43816
 GMS-2022-20
 CVE-2022-0778

--- a/.trivyignore
+++ b/.trivyignore
@@ -2,4 +2,5 @@
 CVE-2021-41092
 CVE-2021-41103
 # awaiting to fix https://github.com/aquasecurity/trivy/issues/1870
+CVE-2021-43816
 GMS-2022-20

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,5 @@
 # awaiting to fix https://github.com/aquasecurity/trivy/issues/1523
 CVE-2021-41092
 CVE-2021-41103
+# awaiting to fix https://github.com/aquasecurity/trivy/issues/1870
+GMS-2022-20

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,6 @@
 # awaiting to fix https://github.com/aquasecurity/trivy/issues/1523
 CVE-2021-41092
 CVE-2021-41103
+
+GMS-2022-20
+CVE-2022-0778

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --no-cache add ca-certificates \
     && which cat
 
 # download trivy
-ARG TRIVY_VERSION=0.24.4
+ARG TRIVY_VERSION=0.25.0
 RUN wget -O- https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz | \
     tar -xzf - -C / \
     && /trivy --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --no-cache add ca-certificates \
     && which cat
 
 # download trivy
-ARG TRIVY_VERSION=0.22.0
+ARG TRIVY_VERSION=0.24.4
 RUN wget -O- https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz | \
     tar -xzf - -C / \
     && /trivy --version


### PR DESCRIPTION
Updated Trivy to most recent version as per https://github.com/aquasecurity/trivy/releases